### PR TITLE
Log packets denied by netpol in iptables.log

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -810,7 +810,8 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(version string) (map[s
 
 		// add default DROP rule at the end of chain
 		comment = "default rule to REJECT traffic destined for POD name:" + pod.name + " namespace: " + pod.namespace
-		args = []string{"-m", "comment", "--comment", comment, "-j", "REJECT"}
+		// args = []string{"-m", "comment", "--comment", comment, "-j", "REJECT"}
+		args = []string{"-m", "comment", "--comment", comment, "-j", "LOG_DROP"}
 		err = iptablesCmdHandler.AppendUnique("filter", podFwChainName, args...)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to run iptables command: %s", err.Error())


### PR DESCRIPTION
**iptables rules generated by kube-router before the change**
<img width="1680" alt="image" src="https://github.com/dialpad/kube-router/assets/54698707/5dae4585-1154-4d39-a168-a273c514851d">


**iptables rules generated by kube-router after the change**
<img width="1676" alt="image" src="https://github.com/dialpad/kube-router/assets/54698707/9fff4e2b-215d-4595-9b6f-ac03571010ef">


**iptables.log showing denied packet**
<img width="1649" alt="image" src="https://github.com/dialpad/kube-router/assets/54698707/91ec3008-c0aa-4879-85c3-d8dbad4d047d">
