### PR TITLE
INFRA-8371: Reverting the custom large port range commit

### DIFF
--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -487,11 +487,7 @@ func (npc *NetworkPolicyController) appendRuleToPolicyChain(policyChainName, com
 			multiport := fmt.Sprintf("%s:%s", dPort, endDport)
 			args = append(args, "--dport", multiport)
 		} else {
-		        if dPort == "16384" && protocol == "UDP" {
-		            args = append(args, "--dport", "16384:32768")
-		        } else {
-		            args = append(args, "--dport", dPort)
-		        }
+		        args = append(args, "--dport", dPort)
 		}
 	}
 


### PR DESCRIPTION
JIRA : https://dialpad.atlassian.net/browse/INFRA-8371.

Under INFRA-7337, We have added one custom commit [Adding large port range if endport is not present · dialpad/kube-router@e8c3f2f](https://github.com/dialpad/kube-router/commit/e8c3f2fdc854ea939d2a9778a9ab87b13b345f4c) to support large port range functionality in kube-router. Now we are sending endPort from netpol to kube-router. So we should remove this kube-router custom commit.

We should also update this new kube-router to GAR and changes ansible [task](https://github.com/dialpad/servers/blob/1d07d06edae8172819639597766f47b3708c6f52/ansible/roles/kube_node/tasks/kube-router.yml#L49) to pull this new Kube-router binary instead of https://storage.googleapis.com/fstinstallbinaries/kube-router-custom-binary-v2.2.2-with-port.

Tested iptables-save with this updated kube-router binary. Port range is showing perfectly fine.
<img width="1706" alt="image" src="https://github.com/user-attachments/assets/7e39cb4f-9d28-4eb3-870e-c5fe10dff4e0" />

